### PR TITLE
Fixed all the connection errors on startup, e.g. could not connect to…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - db
       - be
       - mongodb
+    networks:
+      - mynw
 
   db:
     image: novyl/jtl-reporter-db
@@ -23,7 +25,10 @@ services:
       timeout: 5s
       retries: 10
     environment:
+      - DB_HOST=host.docker.localhost
       - POSTGRES_HOST_AUTH_METHOD=trust
+    networks:
+      - mynw
 
   mongodb:
     image: mongo:4.2.5-bionic
@@ -35,26 +40,32 @@ services:
       - ./mongodb/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     ports: 
       - "27020:27017"
-
+    networks:
+      - mynw
   be:
     image: novyl/jtl-reporter-be:v3.4.0
     ports:
       - "5000:5000"
     environment:
-      - DB_HOST=db
+      - DB_HOST=host.docker.internal
       - MONGO_CONNECTION_STRING=mongodb://mongodb:27017
       - JWT_TOKEN=27JU4qy73hchTMLoH8w9m # please change this token
       - JWT_TOKEN_LOGIN=GdK6TrCvX7rJRZJVg4ijt  # please change this token, the same must be used for listener service
+    networks:
+      - mynw
 
   migration:
     image: novyl/jtl-reporter-be:v3.4.0
     environment:
+        - DB_HOST=host.docker.internal
         - DATABASE_URL=postgres://postgres@db/jtl_report
     command: npm run migrate up
     depends_on:
       db:
         condition: service_healthy
-  
+    networks:
+      - mynw
+
   listener:
     image: novyl/jtl-reporter-listener-service:v1.0.1
     ports:
@@ -62,6 +73,9 @@ services:
     environment: 
       - MONGO_CONNECTION_STRING=mongodb://mongodb:27017
       - JWT_TOKEN=GdK6TrCvX7rJRZJVg4ijt # paste the same token as in be service - JWT_TOKEN_LOGIN
-    
-    
+    networks:
+      - mynw
 
+networks:
+  mynw:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - be
       - mongodb
     networks:
-      - mynw
+      - jtl_network
 
   db:
     image: novyl/jtl-reporter-db
@@ -25,10 +25,10 @@ services:
       timeout: 5s
       retries: 10
     environment:
-      - DB_HOST=host.docker.localhost
+      - DB_HOST=db
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
-      - mynw
+      - jtl_network
 
   mongodb:
     image: mongo:4.2.5-bionic
@@ -41,30 +41,29 @@ services:
     ports: 
       - "27020:27017"
     networks:
-      - mynw
+      - jtl_network
   be:
     image: novyl/jtl-reporter-be:v3.4.0
     ports:
       - "5000:5000"
     environment:
-      - DB_HOST=host.docker.internal
+      - DB_HOST=db
       - MONGO_CONNECTION_STRING=mongodb://mongodb:27017
       - JWT_TOKEN=27JU4qy73hchTMLoH8w9m # please change this token
       - JWT_TOKEN_LOGIN=GdK6TrCvX7rJRZJVg4ijt  # please change this token, the same must be used for listener service
     networks:
-      - mynw
+      - jtl_network
 
   migration:
     image: novyl/jtl-reporter-be:v3.4.0
     environment:
-        - DB_HOST=host.docker.internal
         - DATABASE_URL=postgres://postgres@db/jtl_report
     command: npm run migrate up
     depends_on:
       db:
         condition: service_healthy
     networks:
-      - mynw
+      - jtl_network
 
   listener:
     image: novyl/jtl-reporter-listener-service:v1.0.1
@@ -74,8 +73,8 @@ services:
       - MONGO_CONNECTION_STRING=mongodb://mongodb:27017
       - JWT_TOKEN=GdK6TrCvX7rJRZJVg4ijt # paste the same token as in be service - JWT_TOKEN_LOGIN
     networks:
-      - mynw
+      - jtl_network
 
 networks:
-  mynw:
+  jtl_network:
     driver: bridge


### PR DESCRIPTION
… postgres Error: getaddrinfo ENOTFOUND
errors:
```
migration_1  | could not connect to postgres Error: getaddrinfo ENOTFOUND db
migration_1  |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26) {
migration_1  |   errno: 'ENOTFOUND',
migration_1  |   code: 'ENOTFOUND',
migration_1  |   syscall: 'getaddrinfo',
migration_1  |   hostname: 'db'
```
for MongoDB:
```
{"message":"Error while connecting to MongoDB: MongoServerSelectionError: connect ECONNREFUSED 172.18.0.3:27017","level":"error"}{"message":"Error while connecting to MongoDB: MongoServerSelectionError: connect ECONNREFUSED 172.18.0.3:27017","level":"error"}
```
Fix: Please see the diff