### PR TITLE
Csv fix

### DIFF
--- a/scripts/jtl_listener.py
+++ b/scripts/jtl_listener.py
@@ -151,7 +151,6 @@ class JtlListener:
             response_message,
             data_type,
             success,
-            exception,
             str(response_length),
             bytes_sent,
             str(group_threads),

--- a/scripts/jtl_listener.py
+++ b/scripts/jtl_listener.py
@@ -164,7 +164,7 @@ class JtlListener:
         # https://datatracker.ietf.org/doc/html/rfc4180
         # It encloses all fields in double quotes and escape single double-quotes chars with double double quotes.
         # Example: " -> ""
-        csv_row_str = self.field_delimiter.join(['"' + x.replace('"', '""') + '"' for x in row]) + '\n'
+        csv_row_str = self.field_delimiter.join(['"' + x.replace('"', '""') + '"' for x in row])
         self.csv_results.append(csv_row_str)
 
     def _request_success(self, request_type, name, response_time, response_length, **kw):

--- a/scripts/jtl_listener.py
+++ b/scripts/jtl_listener.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import os
 import requests
 import socket
+import csv
+import io
 
 
 class JtlListener:
@@ -160,7 +162,7 @@ class JtlListener:
             connect,
             hostname
         ]
-        self.csv_results.append(self.field_delimiter.join(row))
+        self.csv_results.append(self._list_to_csv_row(row))
 
     def _request_success(self, request_type, name, response_time, response_length, **kw):
         self.add_result("true", request_type, name,
@@ -169,3 +171,11 @@ class JtlListener:
     def _request_failure(self, request_type, name, response_time, response_length, exception, **kw):
         self.add_result("false", request_type, name, response_time,
                         response_length, str(exception), **kw)
+
+    def _list_to_csv_row(self, lst):
+        mem_file = io.StringIO()
+        writer = csv.writer(mem_file, delimiter=self.field_delimiter)
+        writer.writerow(lst)
+        csv_string = mem_file.getvalue()
+        mem_file.close()
+        return csv_string


### PR DESCRIPTION
2 issues solved here.

### 1. Wrong CSV fields count in rows
'Exception' field removed from CSV header but not from the rows, what generates a not functional csv file.

### 2. Using csv to generate row string
This is solved by using a csv row string generated with the csv module. This takes care of quoting and escaping characters if needed. For example, in previous versions, if the exception field was populated, it was usually included a ',' char, what is the field separator, generating an impossible to parse row.
