### PR TITLE
Add comment about stopping test run in jtl_listener_service.py

### DIFF
--- a/scripts/jtl_listener_service.py
+++ b/scripts/jtl_listener_service.py
@@ -134,6 +134,7 @@ class JtlListener:
 
     def _stop_test_run(self):
         try:
+            ## If you want to set the status, please check: https://jtlreporter.site/docs/integrations/samples-streaming#4-stop-the-test-run
             headers = {
                 "x-access-token": self.api_token
             }


### PR DESCRIPTION
An explanatory comment has been added to the _stop_test_run method in the jtl_listener_service.py script. The comment provides a link for further guidance on setting the status for stopping the test run.