### PR TITLE
[313] Fix PostgreSQL/TimescaleDB Persistent Data Directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: ./db/
       dockerfile: Dockerfile
     volumes:
-      - ./data/jtl_reporter_v5:/var/lib/postgresql/data
+      - ./data/jtl_reporter_v5:/home/postgres/pgdata/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s


### PR DESCRIPTION
This fixes the persistent data directory for  PostgreSQL/TimescaleDB in `docker-compose.yml`; the issue is described in https://github.com/ludeknovy/jtl-reporter/issues/313

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L25-R25): Changed the volume path from `/var/lib/postgresql/data` to `/home/postgres/pgdata/data`.