### PR TITLE
Add Kubernetes Deployment via Helm Charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/
 .idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ Online reporting application to generate reports from JMeter(Taurus), Locust and
   ```
   $ http://IP_ADDRESS:2020
   ```
+
+
+## Kubernetes deployment using Helm charts
+Follows is the basic procedure to deploy locally using minikube for testing, before deploying on the cloud (using CI/CD, kubectl etc.). See `values.yaml` in `helm` folder to change the configuration.
+1. Install Docker, [Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [Helm](https://github.com/helm/helm/releases) and [kubectl](https://kubernetes.io/docs/tasks/tools/)
+2. Clone this repository and navigate to helm folder
+3. Run minikube, and deploy using helm
+
+  ```Shell
+  $ minikube start
+  $ helm install jtl-reporter . -f values.yaml
+  ```
+
+4. Then, you may want to forward the container port for localhost access
+
+  ```Shell
+  $ kubectl port-forward svc/fe 2020:2020
+  ```
+
+5. After forwarding the port, you can access this url in your browser: `http://localhost:2020/`
+
+
   
 ## Documentation 📖
 For additional information please refer to the [documentation](https://jtlreporter.site/docs/).

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: jtl-reporter
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "jtl-reporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "jtl-reporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "jtl-reporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "jtl-reporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:2020 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 2020:$CONTAINER_PORT
+{{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jtl-reporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "jtl-reporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a unique full name for a specific service by suffix
+Usage: {{ include "fe.fullname" . }}
+*/}}
+
+{{- define "fe.fullname" -}}
+{{- printf "%s-fe" (include "jtl-reporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "be.fullname" -}}
+{{- printf "%s-be" (include "jtl-reporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "db.fullname" -}}
+{{- printf "%s-db" (include "jtl-reporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "listener.fullname" -}}
+{{- printf "%s-listener" (include "jtl-reporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "scheduler.fullname" -}}
+{{- printf "%s-scheduler" (include "jtl-reporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "migration.fullname" -}}
+{{- printf "%s-migration" (include "jtl-reporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jtl-reporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "jtl-reporter.labels" -}}
+helm.sh/chart: {{ include "jtl-reporter.chart" . }}
+serviceOwner: {{ .Values.serviceOwner }}
+{{ include "jtl-reporter.componentSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jtl-reporter.componentSelectorLabels" -}}
+app: {{ include "jtl-reporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .component }}
+app.kubernetes.io/name: {{ .component }}
+{{- else }}
+app.kubernetes.io/name: {{ include "jtl-reporter.name" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "jtl-reporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "jtl-reporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/be-deployment.yaml
+++ b/helm/templates/be-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "be.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "be" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "be" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "be" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jtl-reporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: be
+          image: "{{ .Values.be.image.repository }}:{{ .Values.be.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.be.service.port }}
+              protocol: TCP
+          livenessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            exec:
+              command:
+                - pgrep
+                - node
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            exec:
+              command:
+                - pgrep
+                - node
+          startupProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 14
+            periodSeconds: 5
+            exec:
+              command:
+                - pgrep
+                - node
+          env:
+            - name: DB_HOST
+              value: db
+            - name: JWT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: jtlreporter_token
+            - name: JWT_TOKEN_LOGIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: jtlreporter_token_login
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always

--- a/helm/templates/be-service.yaml
+++ b/helm/templates/be-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: be
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "be" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}
+spec:
+  type: {{ .Values.be.service.type }}
+  ports:
+    - name: "{{ .Values.be.service.port }}"
+      type: {{ .Values.be.service.type }}
+      port: {{ .Values.be.service.port }}
+      targetPort: {{ .Values.be.service.port }}
+  selector:
+    {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "be" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}

--- a/helm/templates/db-claim0-persistentvolumeclaim.yaml
+++ b/helm/templates/db-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: db-claim0
+  name: db-claim0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.db.claim }}
+  {{ toYaml . | nindent 2 }}
+  {{- end }}

--- a/helm/templates/db-deployment.yaml
+++ b/helm/templates/db-deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "db.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "db" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "db" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "db" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jtl-reporter.serviceAccountName" . }}
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+      containers:
+        - name: db
+          image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.db.service.port }}
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/postgresql
+              name: db-claim0
+          livenessProbe:
+            exec:
+              command:
+                - /usr/lib/postgresql/17/bin/pg_isready
+                - -U
+                - postgres
+            failureThreshold: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /usr/lib/postgresql/17/bin/pg_isready
+                - -U
+                - postgres
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - /usr/lib/postgresql/17/bin/pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 10
+            failureThreshold: 14
+            periodSeconds: 5
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: trust
+      restartPolicy: Always
+      volumes:
+        - name: db-claim0
+          persistentVolumeClaim:
+            claimName: db-claim0

--- a/helm/templates/db-service.yaml
+++ b/helm/templates/db-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "db" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}
+spec:
+  type: {{ .Values.db.service.type }}
+  ports:
+    - name: "{{ .Values.db.service.port }}"
+      port: {{ .Values.db.service.port }}
+      targetPort: {{ .Values.db.service.port }}
+  selector:
+    {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "db" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}

--- a/helm/templates/fe-deployment.yaml
+++ b/helm/templates/fe-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fe.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "fe" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "fe" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "fe" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jtl-reporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: fe
+          image: "{{ .Values.fe.image.repository }}:{{ .Values.fe.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- with .Values.fe.env }}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 80
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 80
+          startupProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 14
+            periodSeconds: 5
+            httpGet:
+              path: /healthz
+              port: 80
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always

--- a/helm/templates/fe-service.yaml
+++ b/helm/templates/fe-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fe
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "fe" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}
+spec:
+  type: {{ .Values.fe.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.fe.service.port }}
+      targetPort: http
+  selector:
+    {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "fe" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "jtl-reporter.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "jtl-reporter.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jtl-reporter.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "jtl-reporter.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/listener-deployment.yaml
+++ b/helm/templates/listener-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "listener.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "listener" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "listener" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "listener" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jtl-reporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: listener
+          image: "{{ .Values.listener.image.repository }}:{{ .Values.listener.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.listener.service.port }}
+              protocol: TCP
+          livenessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            exec:
+              command:
+                - pgrep
+                - node
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            exec:
+              command:
+                - pgrep
+                - node
+          startupProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 14
+            periodSeconds: 5
+            exec:
+              command:
+                - pgrep
+                - node
+          env:
+            - name: DB_HOST
+              value: db
+            - name: JWT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: jtlreporter_token
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always

--- a/helm/templates/listener-service.yaml
+++ b/helm/templates/listener-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: listener
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "listener" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}
+spec:
+  type: {{ .Values.listener.service.type }}
+  ports:
+    - name: "{{ .Values.listener.service.port }}"
+      type: {{ .Values.listener.service.type }}
+      port: {{ .Values.listener.service.port }}
+      targetPort: {{ .Values.listener.service.port }}
+  selector:
+    {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "listener" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}

--- a/helm/templates/migration-job.yaml
+++ b/helm/templates/migration-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "migration.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "migration" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "migration" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migration
+          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+          imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
+          command: ["npm", "run", "migrate", "up"]
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.migration.env.DATABASE_URL | quote }}
+            - name: OPT_OUT_ANALYTICS
+              value: "true"

--- a/helm/templates/scheduler-deployment.yaml
+++ b/helm/templates/scheduler-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "scheduler.fullname" . }}
+  labels:
+    {{- include "jtl-reporter.labels" (dict "component" "scheduler" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "scheduler" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "jtl-reporter.componentSelectorLabels" (dict "component" "scheduler" "Release" .Release "Chart" .Chart "Values" .Values) | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jtl-reporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: scheduler
+          image: "{{ .Values.scheduler.image.repository }}:{{ .Values.scheduler.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            exec:
+              command:
+                - pgrep
+                - node
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            exec:
+              command:
+                - pgrep
+                - node
+          startupProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 14
+            periodSeconds: 5
+            exec:
+              command:
+                - pgrep
+                - node
+          env:
+            - name: DB_HOST
+              value: db
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jtl-reporter.serviceAccountName" . }}
+  labels:
+    {{- include "jtl-reporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "jtl-reporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "jtl-reporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "jtl-reporter.fullname" . }}:8080']
+  restartPolicy: Never

--- a/helm/values-feature.yaml
+++ b/helm/values-feature.yaml
@@ -1,0 +1,1 @@
+replicaCount: 1

--- a/helm/values-int.yaml
+++ b/helm/values-int.yaml
@@ -1,0 +1,1 @@
+replicaCount: 1

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/helm/values-stg.yaml
+++ b/helm/values-stg.yaml
@@ -1,0 +1,3 @@
+replicaCount: 1
+
+  

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,128 @@
+replicaCount: 1
+
+image:
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+secretName: jtl-reporter-secret
+configMapName: jtl-reporter-config
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podAnnotations:
+  fluentbit.io/exclude: "true"
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - paths: [/jtl-reporter]
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+hpa:
+  enabled: false
+
+resources: {}
+#   requests:
+#     memory: "1200Mi"
+#     cpu: "500m"
+#   limits:
+#     memory: "1800Mi"
+#     cpu: "1000m"
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+fe:
+  image:
+    repository: novyl/jtl-reporter-fe
+    tag: v5.0.3
+  env:
+    # To be used with reverse proxy - see more info here: https://github.com/ludeknovy/jtl-reporter/issues/323
+    # - name: BASE_HREF
+    #   value: /jtl-reporter/
+    # - name: API_PREFIX
+    #   value: /jtl-reporter/api
+  service:
+    type: ClusterIP
+    port: 2020
+
+be:
+  image:
+    repository: novyl/jtl-reporter-be
+    tag: v5.0.5
+  service:
+    type: ClusterIP
+    port: 5000
+    
+db:
+  image:
+    repository: jtl-reporter-db
+    tag: v1.0.0
+  service:
+    type: ClusterIP
+    port: 5432
+  claim:
+    resources:
+      requests:
+        storage: 1Gi
+
+listener:
+  image:
+    repository: novyl/jtl-reporter-listener-service
+    tag: v2.1.2
+  service:
+    type: ClusterIP
+    port: 6000
+
+scheduler:
+  image:
+    repository: novyl/jtl-reporter-scheduler
+    tag: v0.0.8
+
+migration:
+  image:
+    repository: novyl/jtl-reporter-be
+    tag: v5.0.5
+  env:
+    DATABASE_URL: "postgres://postgres@db/jtl_report"


### PR DESCRIPTION
This PR introduces support for deploying the project on Kubernetes using Helm charts.

Key components include:

* `values.yaml`: This file allows for easy configuration of the Kubernetes deployment. Users can modify parameters such as replica counts, image versions, resource requests, and more by editing this file.
* `_helpers.tpl`: This file contains reusable template definitions to keep the Helm charts DRY and maintainable.
* `*-deployment.yaml`: These files define the Kubernetes **Deployment** resources for each service (e.g. `fe` or `be`), specifying how the application pods should be created and managed.
* `*-service.yaml`: These files define the Kubernetes **Service** resources for each service (e.g. `fe` or `be`), providing a stable endpoint to access the application within the cluster.
* Read more about it in [Helm charts docs](https://helm.sh/docs/)

This addition provides an alternative deployment method to the existing `docker-compose.yml`, offering scalability and resilience benefits inherent to Kubernetes.