### PR TITLE
Improve/listener resilience and monitor control

### DIFF
--- a/scripts/jtl_listener_service.py
+++ b/scripts/jtl_listener_service.py
@@ -9,7 +9,6 @@ from gevent import Greenlet
 import requests
 from locust.env import Environment
 from locust.runners import WorkerRunner
-from locust.clients import LocustResponse
 from locust.contrib.fasthttp import FastResponse
 
 
@@ -195,11 +194,11 @@ class JtlListener:
                    name: str, 
                    response_time: float, 
                    response_length: int, 
-                   response: Union[LocustResponse, FastResponse], 
+                   response: Union[requests.Response, FastResponse], 
                    context: Any, 
                    exception: Optional[Exception]) -> None:
         timestamp = int(round(time() * 1000))
-        response_message = str(response.reason) if "reason" in dir(response) else ""
+        response_message = str(getattr(response, 'reason', ''))
         status_code = response.status_code
         group_threads = str(self.runner.user_count)
         all_threads = str(self.runner.user_count)
@@ -342,7 +341,7 @@ class JtlListener:
                  name: str, 
                  response_time: float, 
                  response_length: int, 
-                 response: Union[LocustResponse, FastResponse], 
+                 response: Union[requests.Response, FastResponse], 
                  context: Any, 
                  exception: Optional[Exception], 
                  **kw) -> None:

--- a/scripts/jtl_listener_service.py
+++ b/scripts/jtl_listener_service.py
@@ -39,12 +39,12 @@ class JtlListener:
 
         # Listener configuration
         self.flush_size: int = 500  # how many records should be held before flushing to reporter
-        #
+        self.monitor_sent_interval: int = 30  # how often to send CPU usage and memory usage data (in seconds)
         
         # Advanced parameters
         self._batch_size_multiplier: int = 1  # base multiplier for batch size (flush_size * 1)
         self._batch_size_multiplier_growth_threshold: int = 4  # threshold for growing the batch size multiplier (batch_size * 4)
-        # 
+        
         
         # Initialize batch_size_multiplier
         self._current_batch_size_multiplier = self._batch_size_multiplier
@@ -325,7 +325,7 @@ class JtlListener:
             })
             if self._finished:
                 break
-            gevent.sleep(5)
+            gevent.sleep(self.monitor_sent_interval)
 
     def _user_count(self) -> None:
         while True:
@@ -397,12 +397,19 @@ class JtlListener:
         """Handle report to master event (worker side)."""
         data["results"] = self.results[:]
         self.results.clear()
-        data["cpu_usage"] = {
-            "name": client_id, 
-            "timestamp": int(round(time() * 1000)), 
-            "cpu": self._get_cpu(), 
-            "mem": self._get_memory_usage()
-        }
+
+        # Only send monitor data every n seconds instead of every report
+        current_time = time()
+        if not hasattr(self, '_last_cpu_report'):
+            self._last_cpu_report = 0
+        if current_time - self._last_cpu_report >= self.monitor_sent_interval:
+            data["cpu_usage"] = {
+                "name": client_id, 
+                "timestamp": int(round(time() * 1000)), 
+                "cpu": self._get_cpu(), 
+                "mem": self._get_memory_usage()
+            }
+            self._last_cpu_report = current_time
 
     def _worker_report(self, client_id: str, data: Dict[str, Any]) -> None:
         """Handle report from worker event (master side)."""

--- a/scripts/jtl_listener_service.py
+++ b/scripts/jtl_listener_service.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 from time import sleep, time
 from typing import List, Optional, Dict, Any, Union
 
@@ -51,8 +50,14 @@ class JtlListener:
         self._current_batch_size_multiplier = self._batch_size_multiplier
 
         self.env = env
-        self.environment_name = environment_name or self.env.host
+        self.environment_name = environment_name
         self.runner = self.env.runner
+        if self.runner is None:
+            logging.warning(
+                "JtlListener: No runner available (run_single_user mode). "
+                "JTL Reporter disabled for this environment."
+            )
+            return
         self.project_name = project_name
         self.scenario_name = scenario_name
         self.backend_url = backend_url
@@ -156,7 +161,7 @@ class JtlListener:
                 "x-access-token": self.api_token
             }
             payload: Dict[str, Any] = {
-                "environment": self.environment_name
+                "environment": self.environment_name or self.env.host
             }
             response = requests.post(
                 f"{self.be_url}/api/projects/{self.project_name}/scenarios/{self.scenario_name}/items/start-async",
@@ -365,9 +370,9 @@ class JtlListener:
                 self._background_master_monitor = gevent.spawn(self._master_cpu_monitor)
                 self._background_user = gevent.spawn(self._user_count)
 
-            except Exception:
-                logging.error("Error while starting the test")
-                sys.exit(1)
+            except Exception as e:
+                logging.error(f"JtlListener: Error while starting the test: {e}")
+                logging.warning("JtlListener: JTL Reporter disabled for this test run")
 
     def _test_stop(self, *a, **kw) -> None:
         if not self._is_worker():


### PR DESCRIPTION
## Summary
Improve resilience of `JtlListener` by handling `run_single_user` mode (no runner), throttling CPU/memory monitoring in workers, and cleaning up deprecated imports.
## Changes
### refactor: remove unused LocustResponse import, fix type hints, use getattr for response
- Remove `from locust.clients import LocustResponse` — this class was **removed in recent Locust versions**, causing import errors
- Change `_add_result` and `_request` type hints from `Union[LocustResponse, FastResponse]` to `Union[requests.Response, FastResponse]`
- Replace `"reason" in dir(response)` pattern with `getattr(response, 'reason', '')` — safer and more idiomatic
### feat: handle missing runner gracefully and remove sys.exit on test start error
- Add early return with warning when `self.runner is None` (e.g. `run_single_user` mode), disabling JTL Reporter cleanly instead of crashing
- Replace `sys.exit(1)` in `_test_start` exception handler with graceful logging + warning, allowing the test to continue without JTL reporting
- Move `self.environment_name` default (`or self.env.host`) to the API call site for safer resolution
### feat: add configurable monitor_sent_interval and throttle CPU/mem reports in worker
- New configurable `self.monitor_sent_interval: int = 30` to control how often CPU/memory data is sent
- Use `self.monitor_sent_interval` in `_master_cpu_monitor` loop (was hardcoded `5`)
- Throttle CPU/mem reporting in `_report_to_master` to send only every `monitor_sent_interval` seconds, reducing worker→master payload size